### PR TITLE
Fix Private DNS not turning back on after leaving a blacklisted network

### DIFF
--- a/app/src/main/java/com/ericlowry/dnstoggle/data/DnsManager.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/data/DnsManager.kt
@@ -135,6 +135,9 @@ object DnsManager {
 				}
 			}
 			Settings.Global.putString(resolver, Constants.SETTINGS_PRIVATE_DNS_MODE, newMode)
+			if (!handledByAuto) {
+				sharedPreferences.edit { putString(Constants.PREF_PREFERRED_DNS_MODE, newMode) }
+			}
 			if (!isInteractiveMainUi && sharedPreferences.getBoolean(
 					Constants.PREF_SHOW_TOAST,
 					true

--- a/app/src/test/java/com/ericlowry/dnstoggle/DnsManagerTest.kt
+++ b/app/src/test/java/com/ericlowry/dnstoggle/DnsManagerTest.kt
@@ -1,0 +1,71 @@
+package com.ericlowry.dnstoggle
+
+import androidx.core.content.edit
+import androidx.test.core.app.ApplicationProvider
+import com.ericlowry.dnstoggle.data.Constants
+import com.ericlowry.dnstoggle.data.DnsManager
+import com.ericlowry.dnstoggle.data.DnsSettingsRepository
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@org.robolectric.annotation.Config(application = DnsToggleApplication::class, sdk = [34])
+class DnsManagerTest {
+
+	private lateinit var app: DnsToggleApplication
+
+	@Before
+	fun setup() {
+		app = ApplicationProvider.getApplicationContext()
+		DnsSettingsRepository.initialize(app)
+		app.detectedSsid = null
+	}
+
+	@Test
+	fun manualToggleOn_updatesPreferredDnsMode() {
+		app.getPrefs().edit { putString(Constants.PREF_PREFERRED_DNS_MODE, Constants.DNS_MODE_OPPORTUNISTIC) }
+
+		DnsManager.togglePrivateDns(app, enabled = true, targetHostname = "dns.google")
+
+		assertEquals(
+			Constants.DNS_MODE_HOSTNAME,
+			app.getPrefs().getString(Constants.PREF_PREFERRED_DNS_MODE, null)
+		)
+	}
+
+	@Test
+	fun manualToggleOff_updatesPreferredDnsMode() {
+		app.getPrefs().edit { putString(Constants.PREF_PREFERRED_DNS_MODE, Constants.DNS_MODE_HOSTNAME) }
+
+		DnsManager.togglePrivateDns(app, enabled = false)
+
+		assertEquals(
+			Constants.DNS_MODE_OPPORTUNISTIC,
+			app.getPrefs().getString(Constants.PREF_PREFERRED_DNS_MODE, null)
+		)
+	}
+
+	@Test
+	fun autoBlacklistDrivenToggleOff_doesNotOverwritePreferredDnsMode() {
+		// Regression test: turning DNS off because the current SSID is auto-blacklisted must
+		// not clobber the user's global preference, or leaving that SSID later would restore
+		// the wrong mode (the bug this test guards against).
+		val prefs = app.getPrefs()
+		prefs.edit {
+			putBoolean(Constants.PREF_AUTO_BLACKLIST, true)
+			putString(Constants.PREF_PREFERRED_DNS_MODE, Constants.DNS_MODE_HOSTNAME)
+		}
+		app.detectedSsid = "TestSSID"
+
+		DnsManager.togglePrivateDns(app, enabled = false)
+
+		assertEquals(
+			Constants.DNS_MODE_HOSTNAME,
+			prefs.getString(Constants.PREF_PREFERRED_DNS_MODE, null)
+		)
+		assertEquals(setOf("TestSSID"), DnsSettingsRepository.blacklist.value)
+	}
+}


### PR DESCRIPTION
If you turn Private DNS on, connect to a wifi network that's in your blacklist (so it gets auto disabled), then leave that network, DNS should turn back on. In some cases it doesn't.

The app saves your preferred DNS mode once, the first time you open it, and uses that saved value to restore after leaving a blacklisted network. If your actual preference changes after that first launch, the restore can end up using the old saved value instead of your current one.

This updates it to save your preference every time you toggle DNS yourself, so the restore always reflects your latest choice. Added a test covering that scenario, plus making sure the auto blacklist path still doesn't touch it (that one's only supposed to affect the current network, not your global setting).