### PR TITLE
Add Shizuku as an option for granting the DNS permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A tiny Android app that allows you to easily toggle your phone's Private DNS thr
 
 > [!WARNING]
 >
-> To modify the Private DNS system settings, this app requires the `WRITE_SECURE_SETTINGS` permission. Since this is a protected system permission, you must either have a rooted device or manually grant the permission using [ADB](https://developer.android.com/tools/adb).
+> To modify the Private DNS system settings, this app requires the `WRITE_SECURE_SETTINGS` permission. Since this is a protected system permission, you must either have a rooted device, use [Shizuku](https://shizuku.rikka.app/) (no PC or root required after a one-time setup), or manually grant the permission using [ADB](https://developer.android.com/tools/adb).
 >
 > If your device is not rooted, you can grant the required permission by connecting your phone to a computer with USB debugging enabled and running the following ADB command:
 >
@@ -66,7 +66,7 @@ If you encounter issues not covered here, please [open a support ticket](https:/
 
 ## Permissions
 
-- **WRITE_SECURE_SETTINGS**: Required to modify system Private DNS settings. Must be granted via root or using ADB.
+- **WRITE_SECURE_SETTINGS**: Required to modify system Private DNS settings. Must be granted via root, Shizuku, or using ADB.
 - **INTERNET** _(optional)_: Used to verify that your Custom DNS Provider is online and reachable before applying it.
 - **Location & Nearby Devices** _(optional)_: Required only for **Wi-Fi Blocklist** automation. Used to identify the Wi-Fi network name (SSID) locally.
 - **Notifications** _(optional)_: Used for status alerts when Private DNS is automatically adjusted.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,10 @@ android {
 		sourceCompatibility = JavaVersion.VERSION_11
 		targetCompatibility = JavaVersion.VERSION_11
 	}
+	buildFeatures {
+		aidl = true
+		buildConfig = true
+	}
 	dependenciesInfo {
 		includeInApk = false
 		includeInBundle = false
@@ -52,6 +56,8 @@ dependencies {
 	implementation(libs.androidx.activity)
 	implementation(libs.androidx.constraintlayout)
 	implementation(libs.androidx.lifecycle.viewmodel.ktx)
+	implementation(libs.shizuku.api)
+	implementation(libs.shizuku.provider)
 	testImplementation(libs.junit)
 	testImplementation(libs.robolectric)
 	testImplementation(libs.kotlinx.coroutines.test)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,8 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# The Shizuku UserService is instantiated by reflection in a remote process.
+-keep class com.ericlowry.dnstoggle.shizuku.ShizukuUserService {
+    public <init>();
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,6 +136,14 @@
 				android:value="Monitoring Wi-Fi network connectivity to automate Private DNS mode toggling based on user-defined SSID blacklist." />
 		</service>
 
+		<provider
+			android:name="rikka.shizuku.ShizukuProvider"
+			android:authorities="${applicationId}.shizuku"
+			android:multiprocess="false"
+			android:enabled="true"
+			android:exported="true"
+			android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+
 		<receiver
 			android:name=".service.BootReceiver"
 			android:exported="false">

--- a/app/src/main/aidl/com/ericlowry/dnstoggle/shizuku/IShizukuUserService.aidl
+++ b/app/src/main/aidl/com/ericlowry/dnstoggle/shizuku/IShizukuUserService.aidl
@@ -1,0 +1,6 @@
+package com.ericlowry.dnstoggle.shizuku;
+
+interface IShizukuUserService {
+    void destroy() = 16777114;
+    boolean grantWriteSecureSettings(String packageName) = 1;
+}

--- a/app/src/main/java/com/ericlowry/dnstoggle/service/DnsToggleService.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/service/DnsToggleService.kt
@@ -16,7 +16,7 @@ import com.ericlowry.dnstoggle.data.Constants
 import com.ericlowry.dnstoggle.data.DnsManager
 import com.ericlowry.dnstoggle.data.DnsSettingsRepository
 import com.ericlowry.dnstoggle.ui.MainActivity
-import com.ericlowry.dnstoggle.util.RootUtils
+import com.ericlowry.dnstoggle.util.attemptSecureSettingsGrant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -43,7 +43,7 @@ class DnsToggleService : TileService() {
 		serviceScope.launch(Dispatchers.IO) {
 			if (checkSelfPermission(Manifest.permission.WRITE_SECURE_SETTINGS) != PackageManager.PERMISSION_GRANTED) {
 				// Attempt root grant
-				if ((RootUtils.grantSecureSettingsPermission(packageName)) &&
+				if ((attemptSecureSettingsGrant(this@DnsToggleService, packageName)) &&
 					(checkSelfPermission(Manifest.permission.WRITE_SECURE_SETTINGS) == PackageManager.PERMISSION_GRANTED)
 				) {
 					// Success

--- a/app/src/main/java/com/ericlowry/dnstoggle/shizuku/ShizukuUserService.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/shizuku/ShizukuUserService.kt
@@ -1,0 +1,18 @@
+package com.ericlowry.dnstoggle.shizuku
+
+class ShizukuUserService : IShizukuUserService.Stub() {
+
+	override fun destroy() {
+		System.exit(0)
+	}
+
+	override fun grantWriteSecureSettings(packageName: String): Boolean {
+		return try {
+			val process = Runtime.getRuntime()
+				.exec(arrayOf("pm", "grant", packageName, "android.permission.WRITE_SECURE_SETTINGS"))
+			process.waitFor() == 0
+		} catch (e: Exception) {
+			false
+		}
+	}
+}

--- a/app/src/main/java/com/ericlowry/dnstoggle/ui/MainActivity.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/ui/MainActivity.kt
@@ -44,7 +44,7 @@ import com.ericlowry.dnstoggle.service.TileServiceCompat
 import com.ericlowry.dnstoggle.util.BackupManager
 import com.ericlowry.dnstoggle.util.NetworkUtils
 import com.ericlowry.dnstoggle.util.PermissionHelper
-import com.ericlowry.dnstoggle.util.RootUtils
+import com.ericlowry.dnstoggle.util.attemptSecureSettingsGrant
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.button.MaterialButton
@@ -218,7 +218,7 @@ class MainActivity : AppCompatActivity() {
 			) == true && !PermissionHelper.hasSecureSettingsPermission(this)
 		) {
 			lifecycleScope.launch {
-				RootUtils.grantSecureSettingsPermission(packageName)
+				attemptSecureSettingsGrant(this@MainActivity, packageName)
 				updateMainPermissionUiState()
 				if (!PermissionHelper.hasSecureSettingsPermission(this@MainActivity)) {
 					showInitialPermissionDialog()
@@ -420,7 +420,7 @@ class MainActivity : AppCompatActivity() {
 				// Attempt root grant again
 				setLoadingState(true)
 				lifecycleScope.launch {
-					RootUtils.grantSecureSettingsPermission(packageName)
+					attemptSecureSettingsGrant(this@MainActivity, packageName)
 					setLoadingState(false)
 					updateMainPermissionUiState()
 
@@ -511,7 +511,7 @@ class MainActivity : AppCompatActivity() {
 			} else {
 				setLoadingState(true)
 				lifecycleScope.launch {
-					val success = RootUtils.grantSecureSettingsPermission(packageName)
+					val success = attemptSecureSettingsGrant(this@MainActivity, packageName)
 					setLoadingState(false)
 					updateMainPermissionUiState()
 
@@ -981,7 +981,7 @@ class MainActivity : AppCompatActivity() {
 				setLoadingState(true)
 				lifecycleScope.launch {
 					val startTime = System.currentTimeMillis()
-					RootUtils.grantSecureSettingsPermission(packageName)
+					attemptSecureSettingsGrant(this@MainActivity, packageName)
 
 					val elapsedTime = System.currentTimeMillis() - startTime
 					if (elapsedTime < 1000) delay(1000.milliseconds - elapsedTime.milliseconds)

--- a/app/src/main/java/com/ericlowry/dnstoggle/util/ShizukuUtils.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/util/ShizukuUtils.kt
@@ -1,0 +1,121 @@
+package com.ericlowry.dnstoggle.util
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.os.IBinder
+import android.util.Log
+import com.ericlowry.dnstoggle.BuildConfig
+import com.ericlowry.dnstoggle.shizuku.IShizukuUserService
+import com.ericlowry.dnstoggle.shizuku.ShizukuUserService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import rikka.shizuku.Shizuku
+import kotlin.coroutines.resume
+
+object ShizukuUtils {
+	private const val TAG = "ShizukuUtils"
+	private const val PERMISSION_REQUEST_CODE = 12277
+	private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+	private fun userServiceArgs(context: Context): Shizuku.UserServiceArgs =
+		Shizuku.UserServiceArgs(ComponentName(context.packageName, ShizukuUserService::class.java.name))
+			.daemon(false)
+			.processNameSuffix("shizuku")
+			.debuggable(BuildConfig.DEBUG)
+			.version(BuildConfig.VERSION_CODE)
+
+	fun isAvailable(): Boolean {
+		return try {
+			Shizuku.pingBinder() && !Shizuku.isPreV11()
+		} catch (e: Throwable) {
+			false
+		}
+	}
+
+	fun hasPermission(): Boolean {
+		return try {
+			Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
+		} catch (e: Throwable) {
+			false
+		}
+	}
+
+	private suspend fun requestPermission(): Boolean {
+		if (hasPermission()) return true
+		return suspendCancellableCoroutine { cont ->
+			val listener = object : Shizuku.OnRequestPermissionResultListener {
+				override fun onRequestPermissionResult(requestCode: Int, grantResult: Int) {
+					if (requestCode != PERMISSION_REQUEST_CODE) return
+					Shizuku.removeRequestPermissionResultListener(this)
+					if (cont.isActive) {
+						cont.resume(grantResult == PackageManager.PERMISSION_GRANTED)
+					}
+				}
+			}
+			Shizuku.addRequestPermissionResultListener(listener)
+			cont.invokeOnCancellation { Shizuku.removeRequestPermissionResultListener(listener) }
+			try {
+				Shizuku.requestPermission(PERMISSION_REQUEST_CODE)
+			} catch (e: Throwable) {
+				Shizuku.removeRequestPermissionResultListener(listener)
+				if (cont.isActive) cont.resume(false)
+			}
+		}
+	}
+
+	suspend fun grantSecureSettingsPermission(context: Context, packageName: String): Boolean {
+		if (!isAvailable()) return false
+		if (!requestPermission()) return false
+
+		val args = userServiceArgs(context)
+		return suspendCancellableCoroutine { cont ->
+			lateinit var connection: ServiceConnection
+			connection = object : ServiceConnection {
+				override fun onServiceConnected(name: ComponentName, binder: IBinder) {
+					ioScope.launch {
+						val granted = try {
+							if (binder.pingBinder()) {
+								IShizukuUserService.Stub.asInterface(binder)
+									.grantWriteSecureSettings(packageName)
+							} else {
+								false
+							}
+						} catch (e: Exception) {
+							Log.e(TAG, "Failed to grant secure settings permission via Shizuku", e)
+							false
+						} finally {
+							Shizuku.unbindUserService(args, connection, true)
+						}
+						if (cont.isActive) cont.resume(granted)
+					}
+				}
+
+				override fun onServiceDisconnected(name: ComponentName) {}
+			}
+			cont.invokeOnCancellation {
+				try {
+					Shizuku.unbindUserService(args, connection, true)
+				} catch (_: Throwable) {
+				}
+			}
+			try {
+				Shizuku.bindUserService(args, connection)
+			} catch (e: Throwable) {
+				Log.e(TAG, "Failed to bind Shizuku user service", e)
+				if (cont.isActive) cont.resume(false)
+			}
+		}
+	}
+}
+
+suspend fun attemptSecureSettingsGrant(context: Context, packageName: String): Boolean {
+	if (ShizukuUtils.isAvailable() && ShizukuUtils.grantSecureSettingsPermission(context, packageName)) {
+		return true
+	}
+	return RootUtils.grantSecureSettingsPermission(packageName)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,11 +16,11 @@
 
 	<!-- Permissions & ADB Setup -->
 	<string name="permission_required">Permission Required</string>
-	<string name="permission_message">To use this toggle, you must grant settings permissions through root or run this ADB command on your computer with USB debugging enabled:\n\nadb shell pm grant com.ericlowry.dnstoggle android.permission.WRITE_SECURE_SETTINGS</string>
+	<string name="permission_message">To use this toggle, you must grant settings permissions through root, Shizuku, or run this ADB command on your computer with USB debugging enabled:\n\nadb shell pm grant com.ericlowry.dnstoggle android.permission.WRITE_SECURE_SETTINGS</string>
 	<string name="adb_command_label">ADB Command</string>
 	<string name="copy_command">Copy Command</string>
 	<string name="command_copied">Command copied to clipboard</string>
-	<string name="retry_root">Retry Root</string>
+	<string name="retry_root">Retry</string>
 	<string name="root_grant_failed">Root grant failed or denied</string>
 	<string name="permission_granted">Permission granted</string>
 	<string name="main_permission_title">System Settings Permission Required</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ junit = "4.13.2"
 robolectric = "4.16.1"
 coroutines = "1.11.0"
 androidx-test-core = "1.7.0"
+shizuku = "13.1.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -22,6 +23,8 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
+shizuku-api = { group = "dev.rikka.shizuku", name = "api", version.ref = "shizuku" }
+shizuku-provider = { group = "dev.rikka.shizuku", name = "provider", version.ref = "shizuku" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Right now the app only supports root or manually running an adb command to grant WRITE_SECURE_SETTINGS. This adds Shizuku as a third option, no PC or root needed once you've got Shizuku set up.

Under the hood it runs the same "pm grant" command the adb instructions already tell you to run, through Shizuku's shell level service. If Shizuku isn't installed or set up, it falls straight through to the existing root flow, so nothing changes for people not using it.