### PR TITLE
Add optional watchdog to auto disable Private DNS when it breaks your connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ By long-pressing the Quick Settings tile, you can access the configuration menu 
   - Optional automatic DNS hostname reachability check.
 - **Wi-Fi Blocklist**: Automatically disable Private DNS when connected to specific Wi-Fi networks.
   - Optional automated addition/removal of the current Wi-Fi SSID from the blocklist when manually toggling the Quick Settings tile.
+  - Optional connectivity watchdog that auto-disables Private DNS when a network's DNS provider is unreachable, then re-enables it once the network recovers.
 - **VPN toggling**: Automatically set a DNS hostname or toggle Private DNS when a VPN is in use on the device.
 - **Backup & Restore**: Export and import your configuration via password-encrypted `.dnstoggle` files.
 - **Dynamic Tile Labeling**: Rename the Quick Settings tile.

--- a/app/src/main/java/com/ericlowry/dnstoggle/DnsToggleApplication.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/DnsToggleApplication.kt
@@ -35,7 +35,8 @@ class DnsToggleApplication : Application() {
 		SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
 			if (key == Constants.PREF_AUTO_BLACKLIST ||
 				key == Constants.PREF_AUTO_WHITELIST ||
-				key == Constants.PREF_VPN_OVERRIDE_ENABLED
+				key == Constants.PREF_VPN_OVERRIDE_ENABLED ||
+				key == Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED
 			) {
 				updateWifiMonitoringRegistration()
 			}
@@ -176,7 +177,8 @@ class DnsToggleApplication : Application() {
 		val sharedPreferences = getPrefs()
 		val vpnEnabled = sharedPreferences.getBoolean(Constants.PREF_VPN_OVERRIDE_ENABLED, false)
 		val autoEnabled = sharedPreferences.getBoolean(Constants.PREF_AUTO_BLACKLIST, false) ||
-				sharedPreferences.getBoolean(Constants.PREF_AUTO_WHITELIST, false)
+				sharedPreferences.getBoolean(Constants.PREF_AUTO_WHITELIST, false) ||
+				sharedPreferences.getBoolean(Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED, false)
 
 		val blacklist = DnsSettingsRepository.blacklist.value
 		val hasActiveBlacklist = !blacklist.isNullOrEmpty()

--- a/app/src/main/java/com/ericlowry/dnstoggle/data/Constants.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/data/Constants.kt
@@ -22,6 +22,12 @@ object Constants {
 	const val PREF_LAST_USED_HOSTNAME = "last_used_hostname"
 	const val PREF_USB_DEBUGGING_TILE_UNLOCKED = "usb_debugging_tile_unlocked"
 
+	// Connectivity Watchdog Keys
+	const val PREF_CONNECTIVITY_WATCHDOG_ENABLED = "connectivity_watchdog_enabled"
+	const val PREF_CONNECTIVITY_WATCHDOG_DEBOUNCE_SECONDS = "connectivity_watchdog_debounce_seconds"
+	const val PREF_SSID_AUTO_DETECTED_BLACKLIST = "ssid_auto_detected_blacklist"
+	const val CONNECTIVITY_WATCHDOG_DEFAULT_DEBOUNCE_SECONDS = 15
+
 	// VPN Override Keys
 	const val PREF_VPN_OVERRIDE_ENABLED = "vpn_override_enabled"
 	const val PREF_VPN_DNS_HOSTNAME = "vpn_dns_hostname"

--- a/app/src/main/java/com/ericlowry/dnstoggle/data/DnsSettingsRepository.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/data/DnsSettingsRepository.kt
@@ -27,6 +27,9 @@ object DnsSettingsRepository {
 	private val _blacklist = MutableStateFlow<Set<String>?>(null)
 	val blacklist: StateFlow<Set<String>?> = _blacklist.asStateFlow()
 
+	private val _autoDetectedBlacklist = MutableStateFlow<Set<String>?>(null)
+	val autoDetectedBlacklist: StateFlow<Set<String>?> = _autoDetectedBlacklist.asStateFlow()
+
 	private val _dnsHostnames = MutableStateFlow<List<DnsHostname>?>(null)
 	val dnsHostnames: StateFlow<List<DnsHostname>?> = _dnsHostnames.asStateFlow()
 
@@ -44,6 +47,7 @@ object DnsSettingsRepository {
 		app = context.applicationContext as DnsToggleApplication
 		sharedPreferences = app.getPrefs()
 		loadBlacklist()
+		loadAutoDetectedBlacklist()
 		loadHostnames()
 		_vpnOverrideEnabled.value =
 			sharedPreferences.getBoolean(Constants.PREF_VPN_OVERRIDE_ENABLED, false)
@@ -89,6 +93,33 @@ object DnsSettingsRepository {
 				sharedPreferences.edit { remove(Constants.PREF_SSID_BLACKLIST) }
 			}
 			_blacklist.value = decryptedSet
+		}
+	}
+
+	private fun loadAutoDetectedBlacklist() {
+		scope.launch {
+			val encryptedSet =
+				sharedPreferences.getStringSet(Constants.PREF_SSID_AUTO_DETECTED_BLACKLIST, emptySet())
+					?: emptySet()
+
+			var keyInvalidated = false
+			val decryptedSet = encryptedSet.mapNotNull {
+				when (val result = EncryptionManager.decrypt(it)) {
+					is EncryptionManager.DecryptResult.Success -> result.data
+					is EncryptionManager.DecryptResult.KeyInvalidated -> {
+						keyInvalidated = true
+						null
+					}
+
+					else -> null
+				}
+			}.toSet()
+
+			if (keyInvalidated) {
+				_isKeyInvalidated.value = true
+				sharedPreferences.edit { remove(Constants.PREF_SSID_AUTO_DETECTED_BLACKLIST) }
+			}
+			_autoDetectedBlacklist.value = decryptedSet
 		}
 	}
 
@@ -179,7 +210,16 @@ object DnsSettingsRepository {
 		_isKeyInvalidated.value = false
 	}
 
-	fun addToBlacklist(ssid: String) {
+	fun addToBlacklist(ssid: String, autoDetected: Boolean = false) {
+		if (autoDetected) {
+			_autoDetectedBlacklist.update { current ->
+				val safeCurrent = current ?: emptySet()
+				if (ssid in safeCurrent) return@update safeCurrent
+				val next = safeCurrent + ssid
+				saveAutoDetectedBlacklistAsync(next)
+				next
+			}
+		}
 		_blacklist.update { current ->
 			val safeCurrent = current ?: emptySet()
 			if (ssid in safeCurrent) return@update safeCurrent
@@ -197,6 +237,13 @@ object DnsSettingsRepository {
 			saveBlacklistAsync(next)
 			next
 		}
+		_autoDetectedBlacklist.update { current ->
+			val safeCurrent = current ?: emptySet()
+			if (ssid !in safeCurrent) return@update safeCurrent
+			val next = safeCurrent - ssid
+			saveAutoDetectedBlacklistAsync(next)
+			next
+		}
 	}
 
 	fun updateSsidInBlacklist(oldSsid: String, newSsid: String) {
@@ -207,12 +254,28 @@ object DnsSettingsRepository {
 			saveBlacklistAsync(next)
 			next
 		}
+		_autoDetectedBlacklist.update { current ->
+			val safeCurrent = current ?: emptySet()
+			if (oldSsid !in safeCurrent) return@update safeCurrent
+			val next = safeCurrent - oldSsid
+			saveAutoDetectedBlacklistAsync(next)
+			next
+		}
 	}
 
 	private fun saveBlacklistAsync(list: Set<String>) {
 		scope.launch {
 			val encryptedSet = list.map { EncryptionManager.encrypt(it) }.toSet()
 			sharedPreferences.edit { putStringSet(Constants.PREF_SSID_BLACKLIST, encryptedSet) }
+		}
+	}
+
+	private fun saveAutoDetectedBlacklistAsync(list: Set<String>) {
+		scope.launch {
+			val encryptedSet = list.map { EncryptionManager.encrypt(it) }.toSet()
+			sharedPreferences.edit {
+				putStringSet(Constants.PREF_SSID_AUTO_DETECTED_BLACKLIST, encryptedSet)
+			}
 		}
 	}
 

--- a/app/src/main/java/com/ericlowry/dnstoggle/data/DnsViewModel.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/data/DnsViewModel.kt
@@ -59,6 +59,12 @@ class DnsViewModel(application: Application) : AndroidViewModel(application) {
 	private val _autoWhitelistEnabled = MutableLiveData<Boolean>()
 	val autoWhitelistEnabled: LiveData<Boolean> = _autoWhitelistEnabled
 
+	private val _connectivityWatchdogEnabled = MutableLiveData<Boolean>()
+	val connectivityWatchdogEnabled: LiveData<Boolean> = _connectivityWatchdogEnabled
+
+	private val _connectivityWatchdogDebounceSeconds = MutableLiveData<Int>()
+	val connectivityWatchdogDebounceSeconds: LiveData<Int> = _connectivityWatchdogDebounceSeconds
+
 	private val _hideLauncherIcon = MutableLiveData<Boolean>()
 	val hideLauncherIcon: LiveData<Boolean> = _hideLauncherIcon
 
@@ -106,6 +112,8 @@ class DnsViewModel(application: Application) : AndroidViewModel(application) {
 				Constants.PREF_SHOW_TOAST,
 				Constants.PREF_IS_IN_VPN_OVERRIDE,
 				Constants.PREF_ACTIVE_SSID_OVERRIDE,
+				Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED,
+				Constants.PREF_CONNECTIVITY_WATCHDOG_DEBOUNCE_SECONDS,
 					-> loadSettings()
 			}
 		}
@@ -180,6 +188,18 @@ class DnsViewModel(application: Application) : AndroidViewModel(application) {
 				sharedPreferences.getBoolean(
 					Constants.PREF_AUTO_WHITELIST,
 					false
+				)
+			)
+			_connectivityWatchdogEnabled.postValue(
+				sharedPreferences.getBoolean(
+					Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED,
+					false
+				)
+			)
+			_connectivityWatchdogDebounceSeconds.postValue(
+				sharedPreferences.getInt(
+					Constants.PREF_CONNECTIVITY_WATCHDOG_DEBOUNCE_SECONDS,
+					Constants.CONNECTIVITY_WATCHDOG_DEFAULT_DEBOUNCE_SECONDS
 				)
 			)
 			_hideLauncherIcon.postValue(
@@ -347,6 +367,16 @@ class DnsViewModel(application: Application) : AndroidViewModel(application) {
 	fun setAutoWhitelist(enabled: Boolean) {
 		sharedPreferences.edit { putBoolean(Constants.PREF_AUTO_WHITELIST, enabled) }
 		_autoWhitelistEnabled.value = enabled
+	}
+
+	fun setConnectivityWatchdogEnabled(enabled: Boolean) {
+		sharedPreferences.edit { putBoolean(Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED, enabled) }
+		_connectivityWatchdogEnabled.value = enabled
+	}
+
+	fun setConnectivityWatchdogDebounceSeconds(seconds: Int) {
+		sharedPreferences.edit { putInt(Constants.PREF_CONNECTIVITY_WATCHDOG_DEBOUNCE_SECONDS, seconds) }
+		_connectivityWatchdogDebounceSeconds.value = seconds
 	}
 
 	fun setHideLauncherIcon(hidden: Boolean) {

--- a/app/src/main/java/com/ericlowry/dnstoggle/service/ConnectivityWatchdog.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/service/ConnectivityWatchdog.kt
@@ -1,0 +1,31 @@
+package com.ericlowry.dnstoggle.service
+
+import com.ericlowry.dnstoggle.util.NetworkUtils
+
+object ConnectivityWatchdog {
+	private val PROBE_TARGETS = listOf("1.1.1.1" to 443, "8.8.8.8" to 443)
+
+	suspend fun isDnsSpecificFailure(
+		dnsHostname: String,
+		isNetworkReachable: suspend () -> Boolean = { probeNetwork() },
+		isDnsHostReachable: suspend () -> Boolean = { NetworkUtils.isHostReachable(dnsHostname, 853) }
+	): Boolean {
+		if (!isNetworkReachable()) return false
+		return !isDnsHostReachable()
+	}
+
+	suspend fun isRecovered(
+		dnsHostname: String,
+		isNetworkReachable: suspend () -> Boolean = { probeNetwork() },
+		isDnsHostReachable: suspend () -> Boolean = { NetworkUtils.isHostReachable(dnsHostname, 853) }
+	): Boolean {
+		return isNetworkReachable() && isDnsHostReachable()
+	}
+
+	private suspend fun probeNetwork(): Boolean {
+		for ((host, port) in PROBE_TARGETS) {
+			if (NetworkUtils.isHostReachable(host, port)) return true
+		}
+		return false
+	}
+}

--- a/app/src/main/java/com/ericlowry/dnstoggle/service/WifiMonitoringService.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/service/WifiMonitoringService.kt
@@ -51,6 +51,8 @@ class WifiMonitoringService : Service() {
 	private val activeNetworks = mutableMapOf<Network, NetworkCapabilities>()
 	private val serviceScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
 	private var debounceJob: Job? = null
+	private var connectivityWatchdogJob: Job? = null
+	private var retriedAutoBlacklistForNetwork: Network? = null
 
 	private val dnsSettingsObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
 		override fun onChange(selfChange: Boolean) {
@@ -72,7 +74,10 @@ class WifiMonitoringService : Service() {
 
 	private val preferenceChangeListener =
 		SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-			if (key == Constants.PREF_VPN_OVERRIDE_ENABLED || key == Constants.PREF_VPN_DNS_HOSTNAME) {
+			if (key == Constants.PREF_VPN_OVERRIDE_ENABLED ||
+				key == Constants.PREF_VPN_DNS_HOSTNAME ||
+				key == Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED
+			) {
 				evaluateActiveNetworks()
 			}
 		}
@@ -217,6 +222,11 @@ class WifiMonitoringService : Service() {
 	): Boolean {
 		if (oldCaps == null) return true
 
+		if (oldCaps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) != newCaps.hasCapability(
+				NetworkCapabilities.NET_CAPABILITY_VALIDATED
+			)
+		) return true
+
 		// Check transport changes
 		if (oldCaps.hasTransport(NetworkCapabilities.TRANSPORT_VPN) != newCaps.hasTransport(
 				NetworkCapabilities.TRANSPORT_VPN
@@ -242,7 +252,10 @@ class WifiMonitoringService : Service() {
 	private fun evaluateActiveNetworks() {
 		val allCaps = activeNetworks.values
 		val isVpnActive = allCaps.any { it.hasTransport(NetworkCapabilities.TRANSPORT_VPN) }
-		val wifiCaps = allCaps.find { it.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) }
+		val wifiEntry =
+			activeNetworks.entries.find { it.value.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) }
+		val wifiNetwork = wifiEntry?.key
+		val wifiCaps = wifiEntry?.value
 
 		val hasLocationPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
 			checkSelfPermission(Manifest.permission.NEARBY_WIFI_DEVICES) == PackageManager.PERMISSION_GRANTED
@@ -270,6 +283,8 @@ class WifiMonitoringService : Service() {
 		val isInVpnOverride = prefs.getBoolean(Constants.PREF_IS_IN_VPN_OVERRIDE, false)
 
 		if (isVpnActive && vpnOverrideEnabled) {
+			connectivityWatchdogJob?.cancel()
+			connectivityWatchdogJob = null
 			if (!isInVpnOverride) {
 				// Enter VPN override
 				saveCurrentDnsState()
@@ -288,6 +303,8 @@ class WifiMonitoringService : Service() {
 
 		// Normal Wi-Fi logic
 		if (currentSsid == null || currentSsid == "<unknown ssid>" || currentSsid.isEmpty()) {
+			connectivityWatchdogJob?.cancel()
+			connectivityWatchdogJob = null
 			if (prefs.getString(Constants.PREF_ACTIVE_SSID_OVERRIDE, null) != null) {
 				prefs.edit { putString(Constants.PREF_ACTIVE_SSID_OVERRIDE, null) }
 			}
@@ -297,15 +314,24 @@ class WifiMonitoringService : Service() {
 
 		val blacklist = DnsSettingsRepository.blacklist.value ?: emptySet()
 		if (blacklist.contains(currentSsid)) {
+			connectivityWatchdogJob?.cancel()
+			connectivityWatchdogJob = null
 			if (prefs.getString(Constants.PREF_ACTIVE_SSID_OVERRIDE, null) != currentSsid) {
 				prefs.edit { putString(Constants.PREF_ACTIVE_SSID_OVERRIDE, currentSsid) }
 			}
-			applyOpportunisticDns(currentSsid)
+			val isAutoDetected =
+				DnsSettingsRepository.autoDetectedBlacklist.value?.contains(currentSsid) == true
+			applyOpportunisticDns(
+				currentSsid,
+				if (isAutoDetected) R.string.notif_connectivity_watchdog_disabled else R.string.notif_dns_disabled_auto
+			)
+			maybeRetryAutoDetectedSsid(currentSsid, isAutoDetected, wifiNetwork)
 		} else {
 			if (prefs.getString(Constants.PREF_ACTIVE_SSID_OVERRIDE, null) != null) {
 				prefs.edit { putString(Constants.PREF_ACTIVE_SSID_OVERRIDE, null) }
 			}
 			restorePreferredDns()
+			evaluateConnectivityWatchdog(currentSsid, wifiCaps)
 		}
 	}
 
@@ -356,9 +382,84 @@ class WifiMonitoringService : Service() {
 		networkCallback = null
 	}
 
-	private fun applyOpportunisticDns(ssid: String) {
+	private fun applyOpportunisticDns(
+		ssid: String,
+		reasonStringResId: Int = R.string.notif_dns_disabled_auto
+	) {
 		debounceJob?.cancel()
-		updateDnsSetting(Constants.DNS_MODE_OPPORTUNISTIC, ssid)
+		updateDnsSetting(Constants.DNS_MODE_OPPORTUNISTIC, ssid, reasonStringResId)
+	}
+
+	private fun evaluateConnectivityWatchdog(ssid: String, wifiCaps: NetworkCapabilities?) {
+		val prefs = getPrefs()
+		if (!prefs.getBoolean(Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED, false) ||
+			cachedDnsMode != Constants.DNS_MODE_HOSTNAME
+		) {
+			connectivityWatchdogJob?.cancel()
+			connectivityWatchdogJob = null
+			return
+		}
+
+		if (wifiCaps?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) == true) {
+			connectivityWatchdogJob?.cancel()
+			connectivityWatchdogJob = null
+			return
+		}
+
+		if (connectivityWatchdogJob?.isActive == true) return
+
+		val hostname = Global.getString(contentResolver, Constants.SETTINGS_PRIVATE_DNS_SPECIFIER)
+		if (hostname.isNullOrEmpty()) return
+
+		val debounceSeconds = prefs.getInt(
+			Constants.PREF_CONNECTIVITY_WATCHDOG_DEBOUNCE_SECONDS,
+			Constants.CONNECTIVITY_WATCHDOG_DEFAULT_DEBOUNCE_SECONDS
+		)
+
+		connectivityWatchdogJob = serviceScope.launch {
+			delay(debounceSeconds.seconds)
+
+			val stillNotValidated = activeNetworks.values
+				.find { it.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) }
+				?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) != true
+
+			if (!stillNotValidated ||
+				cachedDnsMode != Constants.DNS_MODE_HOSTNAME ||
+				(application as DnsToggleApplication).detectedSsid != ssid ||
+				!getPrefs().getBoolean(Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED, false)
+			) {
+				return@launch
+			}
+
+			if (ConnectivityWatchdog.isDnsSpecificFailure(hostname)) {
+				DnsSettingsRepository.addToBlacklist(ssid, autoDetected = true)
+			}
+		}
+	}
+
+	private fun maybeRetryAutoDetectedSsid(
+		ssid: String,
+		isAutoDetected: Boolean,
+		wifiNetwork: Network?
+	) {
+		val prefs = getPrefs()
+		if (!isAutoDetected ||
+			!prefs.getBoolean(Constants.PREF_CONNECTIVITY_WATCHDOG_ENABLED, false) ||
+			retriedAutoBlacklistForNetwork == wifiNetwork
+		) {
+			return
+		}
+		retriedAutoBlacklistForNetwork = wifiNetwork
+
+		val hostname = Global.getString(contentResolver, Constants.SETTINGS_PRIVATE_DNS_SPECIFIER)
+		if (hostname.isNullOrEmpty()) return
+
+		serviceScope.launch {
+			if (ConnectivityWatchdog.isRecovered(hostname)) {
+				DnsSettingsRepository.removeFromBlacklist(ssid)
+				dispatchStatusNotification(getString(R.string.notif_connectivity_watchdog_restored, ssid))
+			}
+		}
 	}
 
 	private fun restorePreferredDns() {
@@ -405,14 +506,18 @@ class WifiMonitoringService : Service() {
 		}
 	}
 
-	private fun updateDnsSetting(newMode: String, ssidForNotification: String?) {
+	private fun updateDnsSetting(
+		newMode: String,
+		ssidForNotification: String?,
+		reasonStringResId: Int = R.string.notif_dns_disabled_auto
+	) {
 		try {
 			val resolver = contentResolver
 			if (cachedDnsMode != newMode) {
 				Global.putString(resolver, Constants.SETTINGS_PRIVATE_DNS_MODE, newMode)
 				cachedDnsMode = newMode
 				ssidForNotification?.let {
-					dispatchStatusNotification(getString(R.string.notif_dns_disabled_auto, it))
+					dispatchStatusNotification(getString(reasonStringResId, it))
 				}
 				TileServiceCompat.requestListeningState(
 					this,

--- a/app/src/main/java/com/ericlowry/dnstoggle/ui/DialogHelper.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/ui/DialogHelper.kt
@@ -241,6 +241,56 @@ object DialogHelper {
 			.show()
 	}
 
+	fun showNumberInputDialog(
+		activity: Activity,
+		titleResId: Int,
+		hintResId: Int,
+		initialValue: Int,
+		minValue: Int,
+		maxValue: Int,
+		invalidRangeMessageResId: Int,
+		onSave: (Int) -> Unit,
+	) {
+		val dialogView =
+			LayoutInflater.from(activity).inflate(R.layout.dialog_text_input, null, false)
+		val textInputLayout = dialogView.findViewById<TextInputLayout>(R.id.textInputLayout)
+		val inputTextField = dialogView.findViewById<TextInputEditText>(R.id.etInput)
+
+		textInputLayout.hint = activity.getString(hintResId)
+		inputTextField.inputType = InputType.TYPE_CLASS_NUMBER
+		inputTextField.setText(initialValue.toString())
+		inputTextField.setSelection(inputTextField.text?.length ?: 0)
+
+		val dialog = MaterialAlertDialogBuilder(activity)
+			.setTitle(titleResId)
+			.setView(dialogView)
+			.setPositiveButton(activity.getString(R.string.ok), null)
+			.setNegativeButton(activity.getString(R.string.cancel), null)
+			.create()
+
+		dialog.setOnShowListener {
+			dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+				val value = inputTextField.text.toString().trim().toIntOrNull()
+				if (value == null || value < minValue || value > maxValue) {
+					android.widget.Toast.makeText(
+						activity,
+						invalidRangeMessageResId,
+						android.widget.Toast.LENGTH_SHORT
+					).show()
+				} else {
+					onSave(value)
+					dialog.dismiss()
+				}
+			}
+			inputTextField.requestFocus()
+			dialog.window?.let { window ->
+				WindowCompat.getInsetsController(window, inputTextField)
+					.show(WindowInsetsCompat.Type.ime())
+			}
+		}
+		dialog.show()
+	}
+
 	fun showPasswordDialog(
 		activity: Activity,
 		titleResId: Int,

--- a/app/src/main/java/com/ericlowry/dnstoggle/ui/MainActivity.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/ui/MainActivity.kt
@@ -81,6 +81,9 @@ class MainActivity : AppCompatActivity() {
 
 	private lateinit var switchAutoBlacklist: MaterialSwitch
 	private lateinit var switchAutoWhitelist: MaterialSwitch
+	private lateinit var switchConnectivityWatchdog: MaterialSwitch
+	private lateinit var rowConnectivityWatchdogDebounce: View
+	private lateinit var tvConnectivityWatchdogDebounceValue: TextView
 	private lateinit var switchDisableDnsTest: MaterialSwitch
 	private lateinit var switchShowToast: MaterialSwitch
 	private lateinit var switchHideLauncher: MaterialSwitch
@@ -264,6 +267,9 @@ class MainActivity : AppCompatActivity() {
 
 		switchAutoBlacklist = findViewById(R.id.switchAutoBlacklist)
 		switchAutoWhitelist = findViewById(R.id.switchAutoWhitelist)
+		switchConnectivityWatchdog = findViewById(R.id.switchConnectivityWatchdog)
+		rowConnectivityWatchdogDebounce = findViewById(R.id.rowConnectivityWatchdogDebounce)
+		tvConnectivityWatchdogDebounceValue = findViewById(R.id.tvConnectivityWatchdogDebounceValue)
 		switchDisableDnsTest = findViewById(R.id.switchDisableDnsTest)
 		switchShowToast = findViewById(R.id.switchShowToast)
 		switchHideLauncher = findViewById(R.id.switchHideLauncher)
@@ -341,6 +347,17 @@ class MainActivity : AppCompatActivity() {
 
 		dnsViewModel.autoWhitelistEnabled.observe(this) { enabled ->
 			switchAutoWhitelist.isChecked = enabled
+		}
+
+		dnsViewModel.connectivityWatchdogEnabled.observe(this) { enabled ->
+			switchConnectivityWatchdog.isChecked = enabled
+			rowConnectivityWatchdogDebounce.isEnabled = enabled
+			rowConnectivityWatchdogDebounce.alpha = if (enabled) 1.0f else 0.5f
+		}
+
+		dnsViewModel.connectivityWatchdogDebounceSeconds.observe(this) { seconds ->
+			tvConnectivityWatchdogDebounceValue.text =
+				getString(R.string.connectivity_watchdog_debounce_seconds_format, seconds)
 		}
 
 		dnsViewModel.disableDnsTest.observe(this) { disabled ->
@@ -456,6 +473,14 @@ class MainActivity : AppCompatActivity() {
 			if (isChecked) {
 				checkSsidPermissions(requestIfNotGranted = true)
 			}
+		}
+
+		switchConnectivityWatchdog.setOnCheckedChangeListener { _, isChecked ->
+			dnsViewModel.setConnectivityWatchdogEnabled(isChecked)
+		}
+
+		rowConnectivityWatchdogDebounce.setOnClickListener {
+			showConnectivityWatchdogDebounceDialog()
 		}
 
 		switchDisableDnsTest.setOnCheckedChangeListener { _, isChecked ->
@@ -1165,6 +1190,69 @@ class MainActivity : AppCompatActivity() {
 			dialog.dismiss()
 		}
 		listContainer.addView(autoItemView)
+
+		dialog.show()
+	}
+
+	private fun showConnectivityWatchdogDebounceDialog() {
+		val presets = listOf(10, 15, 30, 60)
+		val currentValue = dnsViewModel.connectivityWatchdogDebounceSeconds.value
+			?: Constants.CONNECTIVITY_WATCHDOG_DEFAULT_DEBOUNCE_SECONDS
+
+		val dialogView = LayoutInflater.from(this)
+			.inflate(R.layout.dialog_dns_selection, findViewById(android.R.id.content), false)
+
+		val dialog = Dialog(this)
+		dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+		dialog.setContentView(dialogView)
+
+		val tvPopupTitle = dialogView.findViewById<TextView>(R.id.tvPopupTitle)
+		tvPopupTitle.text = getString(R.string.connectivity_watchdog_debounce_label)
+
+		val listContainer = dialogView.findViewById<LinearLayout>(R.id.dnsListContainer)
+		val btnCancel = dialogView.findViewById<MaterialButton>(R.id.btnSettings)
+		btnCancel.text = getString(R.string.cancel)
+		btnCancel.setOnClickListener { dialog.dismiss() }
+
+		val totalItems = presets.size + 1
+
+		presets.forEachIndexed { index, seconds ->
+			val itemView = createDnsListItem(
+				listContainer,
+				getString(R.string.connectivity_watchdog_debounce_seconds_format, seconds),
+				null,
+				seconds == currentValue,
+				index,
+				totalItems
+			) {
+				dnsViewModel.setConnectivityWatchdogDebounceSeconds(seconds)
+				dialog.dismiss()
+			}
+			listContainer.addView(itemView)
+		}
+
+		val customItemView = createDnsListItem(
+			listContainer,
+			getString(R.string.connectivity_watchdog_debounce_custom),
+			null,
+			currentValue !in presets,
+			totalItems - 1,
+			totalItems
+		) {
+			dialog.dismiss()
+			DialogHelper.showNumberInputDialog(
+				this,
+				R.string.connectivity_watchdog_debounce_label,
+				R.string.connectivity_watchdog_debounce_label,
+				currentValue,
+				5,
+				300,
+				R.string.connectivity_watchdog_debounce_invalid,
+			) { seconds ->
+				dnsViewModel.setConnectivityWatchdogDebounceSeconds(seconds)
+			}
+		}
+		listContainer.addView(customItemView)
 
 		dialog.show()
 	}

--- a/app/src/main/java/com/ericlowry/dnstoggle/util/NetworkUtils.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/util/NetworkUtils.kt
@@ -7,6 +7,10 @@ import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.os.Build
 import com.ericlowry.dnstoggle.DnsToggleApplication
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.InetSocketAddress
+import java.net.Socket
 
 fun String.stripSsidQuotes(): String {
 	return this.removePrefix("\"").removeSuffix("\"")
@@ -49,6 +53,16 @@ object NetworkUtils {
 
 		return if (ssid == "<unknown ssid>" || ssid.isNullOrEmpty()) null else ssid
 	}
+
+	suspend fun isHostReachable(host: String, port: Int, timeoutMs: Int = 3000): Boolean =
+		withContext(Dispatchers.IO) {
+			try {
+				Socket().use { it.connect(InetSocketAddress(host, port), timeoutMs) }
+				true
+			} catch (e: Exception) {
+				false
+			}
+		}
 
 	fun isValidDnsHostname(hostname: String): Boolean {
 		val hostnameRegex =

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -338,6 +338,49 @@
 						android:layout_marginTop="4dp"
 						android:text="@string/auto_whitelist_on_enable" />
 
+					<com.google.android.material.materialswitch.MaterialSwitch
+						android:id="@+id/switchConnectivityWatchdog"
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:layout_marginTop="4dp"
+						android:text="@string/connectivity_watchdog_toggle" />
+
+					<LinearLayout
+						android:id="@+id/rowConnectivityWatchdogDebounce"
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:layout_marginTop="8dp"
+						android:background="?attr/selectableItemBackground"
+						android:clickable="true"
+						android:focusable="true"
+						android:gravity="center_vertical"
+						android:orientation="horizontal"
+						android:paddingVertical="8dp">
+
+						<TextView
+							android:layout_width="0dp"
+							android:layout_height="wrap_content"
+							android:layout_weight="1"
+							android:text="@string/connectivity_watchdog_debounce_label"
+							android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+						<TextView
+							android:id="@+id/tvConnectivityWatchdogDebounceValue"
+							android:layout_width="wrap_content"
+							android:layout_height="wrap_content"
+							android:textAppearance="?attr/textAppearanceBodyMedium"
+							android:textColor="?attr/colorPrimary"
+							tools:text="15s" />
+
+						<ImageView
+							android:layout_width="20dp"
+							android:layout_height="20dp"
+							android:layout_marginStart="4dp"
+							android:contentDescription="@null"
+							android:src="@drawable/ic_chevron_right"
+							app:tint="?attr/colorOnSurfaceVariant" />
+					</LinearLayout>
+
 					<TextView
 						android:id="@+id/tvPermissionNotice"
 						android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,13 @@
 	<string name="ignore_battery_optimizations">Disable battery restrictions</string>
 	<string name="auto_blacklist_on_disable">Auto-blacklist when disabling</string>
 	<string name="auto_whitelist_on_enable">Auto-whitelist when enabling</string>
+	<string name="connectivity_watchdog_toggle">Auto-disable on connectivity failure</string>
+	<string name="connectivity_watchdog_debounce_label">Wait before disabling</string>
+	<string name="connectivity_watchdog_debounce_custom">Custom…</string>
+	<string name="connectivity_watchdog_debounce_invalid">Enter a value between 5 and 300 seconds</string>
+	<string name="connectivity_watchdog_debounce_seconds_format">%ds</string>
+	<string name="notif_connectivity_watchdog_disabled">Private DNS disabled and blacklisted for %s due to a connectivity issue</string>
+	<string name="notif_connectivity_watchdog_restored">Connectivity restored — Private DNS re-enabled for %s</string>
 	<string name="grant_permission_notice">Location/Nearby permission (including background) required to verify the Wi-Fi SSID.</string>
 	<string name="grant_permission_button">Grant Permissions</string>
 	<string name="permissions_permanently_denied">Location and Nearby devices permissions have been permanently denied. Please enable them in App Settings to use this feature.</string>

--- a/app/src/test/java/com/ericlowry/dnstoggle/ConnectivityWatchdogTest.kt
+++ b/app/src/test/java/com/ericlowry/dnstoggle/ConnectivityWatchdogTest.kt
@@ -1,0 +1,77 @@
+package com.ericlowry.dnstoggle
+
+import com.ericlowry.dnstoggle.service.ConnectivityWatchdog
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectivityWatchdogTest {
+
+	@Test
+	fun networkUnreachable_returnsFalse_regardlessOfDnsHost() = runTest {
+		assertFalse(
+			ConnectivityWatchdog.isDnsSpecificFailure(
+				"dns.example.com",
+				isNetworkReachable = { false },
+				isDnsHostReachable = { false }
+			)
+		)
+		assertFalse(
+			ConnectivityWatchdog.isDnsSpecificFailure(
+				"dns.example.com",
+				isNetworkReachable = { false },
+				isDnsHostReachable = { true }
+			)
+		)
+	}
+
+	@Test
+	fun networkReachable_dnsHostReachable_returnsFalse() = runTest {
+		assertFalse(
+			ConnectivityWatchdog.isDnsSpecificFailure(
+				"dns.example.com",
+				isNetworkReachable = { true },
+				isDnsHostReachable = { true }
+			)
+		)
+	}
+
+	@Test
+	fun networkReachable_dnsHostUnreachable_returnsTrue() = runTest {
+		assertTrue(
+			ConnectivityWatchdog.isDnsSpecificFailure(
+				"dns.example.com",
+				isNetworkReachable = { true },
+				isDnsHostReachable = { false }
+			)
+		)
+	}
+
+	@Test
+	fun isRecovered_requiresBothNetworkAndDnsHostReachable() = runTest {
+		assertTrue(
+			ConnectivityWatchdog.isRecovered(
+				"dns.example.com",
+				isNetworkReachable = { true },
+				isDnsHostReachable = { true }
+			)
+		)
+		assertFalse(
+			ConnectivityWatchdog.isRecovered(
+				"dns.example.com",
+				isNetworkReachable = { false },
+				isDnsHostReachable = { true }
+			)
+		)
+		assertFalse(
+			ConnectivityWatchdog.isRecovered(
+				"dns.example.com",
+				isNetworkReachable = { true },
+				isDnsHostReachable = { false }
+			)
+		)
+	}
+}

--- a/app/src/test/java/com/ericlowry/dnstoggle/DnsSettingsRepositoryTest.kt
+++ b/app/src/test/java/com/ericlowry/dnstoggle/DnsSettingsRepositoryTest.kt
@@ -48,6 +48,37 @@ class DnsSettingsRepositoryTest {
 	}
 
 	@Test
+	fun addToBlacklist_autoDetected_appearsInBothSets() = runTest {
+		val ssid = "AutoDetectedWiFi"
+
+		DnsSettingsRepository.addToBlacklist(ssid, autoDetected = true)
+
+		assertTrue(DnsSettingsRepository.blacklist.value?.contains(ssid) == true)
+		assertTrue(DnsSettingsRepository.autoDetectedBlacklist.value?.contains(ssid) == true)
+	}
+
+	@Test
+	fun addToBlacklist_manual_notInAutoDetectedSet() = runTest {
+		val ssid = "ManualWiFi"
+
+		DnsSettingsRepository.addToBlacklist(ssid)
+
+		assertTrue(DnsSettingsRepository.blacklist.value?.contains(ssid) == true)
+		assertTrue(DnsSettingsRepository.autoDetectedBlacklist.value?.contains(ssid) != true)
+	}
+
+	@Test
+	fun removeFromBlacklist_autoDetected_removedFromBothSets() = runTest {
+		val ssid = "AutoDetectedRemovable"
+
+		DnsSettingsRepository.addToBlacklist(ssid, autoDetected = true)
+		DnsSettingsRepository.removeFromBlacklist(ssid)
+
+		assertTrue(DnsSettingsRepository.blacklist.value?.contains(ssid) != true)
+		assertTrue(DnsSettingsRepository.autoDetectedBlacklist.value?.contains(ssid) != true)
+	}
+
+	@Test
 	fun removeHostname_keepsAtLeastOne() = runTest {
 		val hostname = "dns.google"
 		DnsSettingsRepository.addHostname(hostname)


### PR DESCRIPTION
New opt-in setting (off by default) under Wi-Fi Blocklist. If your Private DNS provider goes down, or a network blocks DoT, Android won't fall back, you just lose internet until you notice and turn it off yourself.

The watchdog watches for the current wifi network losing validation while DNS is on. After a debounce (15s by default, configurable), it checks a plain IP to rule out a general outage, then checks your DNS server specifically. If that confirms the DNS server is the problem, it adds that network to your existing blacklist (marked so it's never confused with ones you added by hand) and turns DNS off there.

Next time you connect to that network it checks again, and un-blacklists automatically once things are working. Networks you blacklisted yourself are never touched by this, only ones the watchdog added.

Right now the test target for the "is the network even up" check is hardcoded (1.1.1.1 and 8.8.8.8). Open to making that configurable too if that seems useful, figured I'd ask before adding more settings than needed.