### PR TITLE
Fix connectivity watchdog false negatives and slow detection

### DIFF
--- a/app/src/main/java/com/ericlowry/dnstoggle/data/Constants.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/data/Constants.kt
@@ -28,7 +28,7 @@ object Constants {
 	const val PREF_CONNECTIVITY_WATCHDOG_PROBE_TARGETS = "connectivity_watchdog_probe_targets"
 	const val PREF_SSID_AUTO_DETECTED_BLACKLIST = "ssid_auto_detected_blacklist"
 	const val CONNECTIVITY_WATCHDOG_DEFAULT_DEBOUNCE_SECONDS = 15
-	const val CONNECTIVITY_WATCHDOG_DEFAULT_PROBE_TARGETS = "9.9.9.9, 149.112.112.112"
+	const val CONNECTIVITY_WATCHDOG_DEFAULT_PROBE_TARGETS = "104.16.132.229, 140.82.112.3"
 
 	// VPN Override Keys
 	const val PREF_VPN_OVERRIDE_ENABLED = "vpn_override_enabled"

--- a/app/src/main/java/com/ericlowry/dnstoggle/util/NetworkUtils.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/util/NetworkUtils.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import com.ericlowry.dnstoggle.DnsToggleApplication
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.net.InetSocketAddress
 import java.net.Socket
 
@@ -56,12 +57,17 @@ object NetworkUtils {
 
 	suspend fun isHostReachable(host: String, port: Int, timeoutMs: Int = 3000): Boolean =
 		withContext(Dispatchers.IO) {
-			try {
-				Socket().use { it.connect(InetSocketAddress(host, port), timeoutMs) }
-				true
-			} catch (e: Exception) {
-				false
-			}
+			// InetSocketAddress resolves the hostname eagerly, before connect()'s own
+			// timeout applies, so a stuck resolver (e.g. a broken private DNS server)
+			// can hang well past timeoutMs unless the whole thing is bounded here too.
+			withTimeoutOrNull(timeoutMs.toLong()) {
+				try {
+					Socket().use { it.connect(InetSocketAddress(host, port), timeoutMs) }
+					true
+				} catch (e: Exception) {
+					false
+				}
+			} ?: false
 		}
 
 	fun isValidDnsHostname(hostname: String): Boolean {


### PR DESCRIPTION
## What does this Pull Request do?

Found this by reproducing a hostile guest network in an emulator instead of guessing.

The default probe targets ("is the network even up") were 9.9.9.9 and 149.112.112.112, both well known DNS resolver IPs. A network blocking your Private DNS provider is likely to also block known resolver IPs on principle, which made the watchdog misread a real DNS-specific outage as a general one and do nothing. Switched the defaults to a Cloudflare CDN edge and a GitHub edge IP instead, neither branded as DNS.

Also, `NetworkUtils.isHostReachable` resolves the hostname before its own connect timeout applies. When the hostname being tested is the one that's broken, that resolution hangs on the system's DNS timeout instead of ours, adding up to 60s of silent delay. Wrapped it in `withTimeoutOrNull` to bound it properly.

Verified both against the exact scenario that triggered them: detection now completes in ~5s instead of never happening.

## Quick Checklist

- [x] I have tested these changes locally on my device/emulator.
- [x] The changes I have introduced do not conflict with F-Droid and IzzyOnDroid policies.
- [ ] (If applicable) I have attached screenshots of any UI changes.