### PR TITLE
Fix EncryptionManagerTest failure under Robolectric

### DIFF
--- a/app/src/test/java/com/ericlowry/dnstoggle/EncryptionManagerTest.kt
+++ b/app/src/test/java/com/ericlowry/dnstoggle/EncryptionManagerTest.kt
@@ -12,11 +12,12 @@ import org.robolectric.RobolectricTestRunner
 class EncryptionManagerTest {
 
 	@Test
-	fun encryptDecrypt_worksWithPrefix() {
+	fun encryptDecrypt_roundTrips() {
+		// Robolectric has no real AndroidKeyStore, so encrypt() always takes its
+		// plaintext-fallback path here and the "enc:" prefix can't be asserted.
+		// The round-trip is the actual guaranteed contract; verify that instead.
 		val original = "secret_dns_hostname"
 		val encrypted = EncryptionManager.encrypt(original)
-
-		assertTrue("Should have prefix", encrypted.startsWith("enc:"))
 
 		val result = EncryptionManager.decrypt(encrypted)
 		assertTrue(result is EncryptionManager.DecryptResult.Success)


### PR DESCRIPTION
## What does this Pull Request do?

Not a bug in `EncryptionManager`. Robolectric has no real `AndroidKeyStore`, so `encrypt()` always takes its plaintext-fallback path in tests, which intentionally skips the `"enc:"` prefix so the data stays recoverable through `decrypt()`'s lenient unprefixed path. The old test asserted the prefix anyway, which only the real-Keystore path can produce.

Adding the prefix to the fallback path to make that assertion pass would actually be wrong: prefixed data is treated strictly by `decrypt()` and never falls back to plaintext (see `decrypt_handlesPrefixedCorruptedData`), so anything "encrypted" without a real key would become unrecoverable instead of just unencrypted.

Rewrote the test to check what's actually guaranteed regardless of Keystore availability: encrypt followed by decrypt round-trips to the original value.

## Quick Checklist

- [x] I have tested these changes locally on my device/emulator.
- [x] The changes I have introduced do not conflict with F-Droid and IzzyOnDroid policies.
- [ ] (If applicable) I have attached screenshots of any UI changes.