### PR TITLE
Integrating PR #21

### DIFF
--- a/app/src/main/java/com/ericlowry/dnstoggle/data/Constants.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/data/Constants.kt
@@ -28,7 +28,7 @@ object Constants {
 	const val PREF_CONNECTIVITY_WATCHDOG_PROBE_TARGETS = "connectivity_watchdog_probe_targets"
 	const val PREF_SSID_AUTO_DETECTED_BLACKLIST = "ssid_auto_detected_blacklist"
 	const val CONNECTIVITY_WATCHDOG_DEFAULT_DEBOUNCE_SECONDS = 15
-	const val CONNECTIVITY_WATCHDOG_DEFAULT_PROBE_TARGETS = "9.9.9.9, 149.112.112.112"
+	const val CONNECTIVITY_WATCHDOG_DEFAULT_PROBE_TARGETS = "104.16.132.229, 140.82.112.3"
 
 	// VPN Override Keys
 	const val PREF_VPN_OVERRIDE_ENABLED = "vpn_override_enabled"

--- a/app/src/main/java/com/ericlowry/dnstoggle/data/Constants.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/data/Constants.kt
@@ -28,7 +28,7 @@ object Constants {
 	const val PREF_CONNECTIVITY_WATCHDOG_PROBE_TARGETS = "connectivity_watchdog_probe_targets"
 	const val PREF_SSID_AUTO_DETECTED_BLACKLIST = "ssid_auto_detected_blacklist"
 	const val CONNECTIVITY_WATCHDOG_DEFAULT_DEBOUNCE_SECONDS = 15
-	const val CONNECTIVITY_WATCHDOG_DEFAULT_PROBE_TARGETS = "104.16.132.229, 140.82.112.3"
+	const val CONNECTIVITY_WATCHDOG_DEFAULT_PROBE_TARGETS = "91.198.174.192, 103.102.166.224, 173.239.79.196"
 
 	// VPN Override Keys
 	const val PREF_VPN_OVERRIDE_ENABLED = "vpn_override_enabled"

--- a/app/src/main/java/com/ericlowry/dnstoggle/service/ConnectivityWatchdog.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/service/ConnectivityWatchdog.kt
@@ -1,9 +1,11 @@
 package com.ericlowry.dnstoggle.service
 
+import com.ericlowry.dnstoggle.data.Constants
 import com.ericlowry.dnstoggle.util.NetworkUtils
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 object ConnectivityWatchdog {
 
@@ -41,10 +43,32 @@ object ConnectivityWatchdog {
 			.map { it.trim() }
 			.filter { it.isNotEmpty() }
 
-		val effectiveTargets = targets.ifEmpty { listOf("9.9.9.9") }
+		val effectiveTargets = targets.ifEmpty {
+			Constants.CONNECTIVITY_WATCHDOG_DEFAULT_PROBE_TARGETS.split(",")
+				.map { it.trim() }
+				.filter { it.isNotEmpty() }
+		}
 
-		effectiveTargets.map { target ->
-			async { NetworkUtils.isHostReachable(target, 443) }
-		}.awaitAll().any { it }
+		val resultChannel = Channel<Boolean>()
+
+		effectiveTargets.forEach { target ->
+			launch {
+				resultChannel.send(NetworkUtils.isHostReachable(target, 443))
+			}
+		}
+
+		var isConnected = false
+		var receivedCount = 0
+		while (receivedCount < effectiveTargets.size) {
+			if (resultChannel.receive()) {
+				isConnected = true
+				break
+			}
+			receivedCount++
+		}
+
+		coroutineContext.cancelChildren()
+
+		return@coroutineScope isConnected
 	}
 }

--- a/app/src/main/java/com/ericlowry/dnstoggle/util/NetworkUtils.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/util/NetworkUtils.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.net.InetSocketAddress
 import java.net.Socket
+import kotlin.time.Duration.Companion.milliseconds
 
 fun String.stripSsidQuotes(): String {
 	return this.removePrefix("\"").removeSuffix("\"")
@@ -57,14 +58,11 @@ object NetworkUtils {
 
 	suspend fun isHostReachable(host: String, port: Int, timeoutMs: Int = 3000): Boolean =
 		withContext(Dispatchers.IO) {
-			// InetSocketAddress resolves the hostname eagerly, before connect()'s own
-			// timeout applies, so a stuck resolver (e.g. a broken private DNS server)
-			// can hang well past timeoutMs unless the whole thing is bounded here too.
-			withTimeoutOrNull(timeoutMs.toLong()) {
+			withTimeoutOrNull(timeoutMs.toLong().milliseconds) {
 				try {
 					Socket().use { it.connect(InetSocketAddress(host, port), timeoutMs) }
 					true
-				} catch (e: Exception) {
+				} catch (_: Exception) {
 					false
 				}
 			} ?: false

--- a/app/src/main/java/com/ericlowry/dnstoggle/util/NetworkUtils.kt
+++ b/app/src/main/java/com/ericlowry/dnstoggle/util/NetworkUtils.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import com.ericlowry.dnstoggle.DnsToggleApplication
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.net.InetSocketAddress
 import java.net.Socket
 
@@ -56,12 +57,17 @@ object NetworkUtils {
 
 	suspend fun isHostReachable(host: String, port: Int, timeoutMs: Int = 3000): Boolean =
 		withContext(Dispatchers.IO) {
-			try {
-				Socket().use { it.connect(InetSocketAddress(host, port), timeoutMs) }
-				true
-			} catch (e: Exception) {
-				false
-			}
+			// InetSocketAddress resolves the hostname eagerly, before connect()'s own
+			// timeout applies, so a stuck resolver (e.g. a broken private DNS server)
+			// can hang well past timeoutMs unless the whole thing is bounded here too.
+			withTimeoutOrNull(timeoutMs.toLong()) {
+				try {
+					Socket().use { it.connect(InetSocketAddress(host, port), timeoutMs) }
+					true
+				} catch (e: Exception) {
+					false
+				}
+			} ?: false
 		}
 
 	fun isValidDnsHostname(hostname: String): Boolean {


### PR DESCRIPTION
- Integrates connectivity watchdog false negatives and slow detection fixes from #21
- Speeds up watchdog tests by stopping at the first negative result
- Connectivity watchdog probe targets set to use Wikimedia and EFF IPs by default.